### PR TITLE
feat: eigenda nitro docker image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -93,6 +93,22 @@ services:
       - "./config:/home/user/.arbitrum"
     command: --conf.file /home/user/.arbitrum/nodeConfig.json
 
+  eigenda-proxy:
+    image: ghcr.io/layr-labs/eigenda-proxy:main
+    ports:
+      - "127.0.0.1:3100:3100"
+    volumes:
+      - "./config:/home/user/.arbitrum"
+    command: >
+      ./eigenda-proxy
+      --addr 127.0.0.1
+      --port 3100
+      --eigenda-disperser-rpc disperser-holesky.eigenda.xyz:443
+      --eigenda-signer-private-key-hex ${PRIVATE_KEY}
+      --eigenda-eth-rpc ${ETH_RPC_URL}
+      --eigenda-svc-manager-addr 0xD4A7E1Bd8015057293f0D0A557088c286942e84b
+    restart: unless-stopped
+
   das-server:
     image: ghcr.io/layr-labs/nitro-eigenda:cfcd9c6
     platform: linux/amd64


### PR DESCRIPTION
replaced offchainlabs nitro docker tag with eigenda's nitro node image, added eigenda-proxy as a service in docker compose

(This PR is pending on new nitro image)

Some logs 
![Screenshot 2024-08-16 at 4 05 29 PM](https://github.com/user-attachments/assets/28751801-de19-465d-bec8-9090739f7cdb)
![Screenshot 2024-08-16 at 4 05 47 PM](https://github.com/user-attachments/assets/4e8469ce-f0f8-4d82-9bd0-508d569c6387)
![Screenshot 2024-08-16 at 4 06 04 PM](https://github.com/user-attachments/assets/70554562-3a84-46fa-87c2-916f15d634b0)

